### PR TITLE
:sparkles: Agrega boton quitar del carrito

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -30,6 +30,14 @@ router.post('/cart', async function (req, res) {
     res.redirect('/cart');
 });
 
+router.post('/cart/delete', async function (req, res) {
+    const productID = +req.body.productid;
+    await CartModel.removeProductFromCart(1, productID);
+
+    
+    res.redirect('/cart');
+});
+
 router.get('/cart', async function (req, res) {
     const cart = await CartModel.findById(1);
     const products = await cart.getProducts();

--- a/src/views/_product-card.html
+++ b/src/views/_product-card.html
@@ -29,6 +29,11 @@
                 </form>
             {% else %}
                 <div class="product__quantity fs-4 bold">
+                    <form action="/cart/delete" method="POST">
+                        <input type="text" class="d-none" name="productid" value="{{ product.id  }}">
+                        <button type="submit" class="btn btn-outline-danger">Quitar del carrito</button>
+                    </form>
+
                     {{ product.CartProduct.quantity }} en carrito
                 </div>
             {% endif %}

--- a/tests/unit/ui/product-card.spec.js
+++ b/tests/unit/ui/product-card.spec.js
@@ -81,6 +81,22 @@ describe('Tarjeta de producto', () => {
         const btn = getByText(document.body, 'Agregar a carrito');
         expect(btn).toBeVisible();
     });
+    test('Deberia tener boton para quitar del carrito', async () => {
+        const product = {
+            name: 'Placard',
+            type: 'home',
+            price: 100,
+            CartProduct: {
+                quantity: 2,
+            },
+        };
+        const html = renderProduct(product);
+        document.body.innerHTML = html;
+
+        expect(queryByText(document.body, 'Agregar a carrito')).toBeNull();
+        const btn = getByText(document.body, 'Quitar del carrito');
+        expect(btn).toBeVisible();
+    });
 
     test('Deberia mostrar la cantidad de items en carrito si el producto esta dentro de un carrito', async () => {
         const product = {


### PR DESCRIPTION
Agrega el boton quitar del carrito que permite decrementar la cantidad de un producto en el carrito en 1.